### PR TITLE
Add support for "go to definition"

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "webpack": "npm run clean && webpack --mode production",
     "webpack:dev": "npm run clean && webpack --mode none",
     "precompile": "npm run lint",
-    "compile": "npm webpack",
+    "compile": "npm run webpack",
     "watch": "webpack watch --mode development"
   },
   "devDependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es2019",
-    "lib": ["ES2019"],
+    "target": "es2020",
+    "lib": ["ES2020"],
 
     "sourceMap": true,
     "incremental": false,


### PR DESCRIPTION
See #4

Since we're using a language server, this code needed to be rewritten anyway.  Now cache the whole AST rather than just the rule names, does a MUCH better job finding words.