### PR TITLE
Use tsc for local development instead of webpack

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,10 +13,7 @@
 			"outFiles": [
 				"${workspaceRoot}/out/**/*.js"
 			],
-			"preLaunchTask": {
-				"type": "npm",
-				"script": "watch"
-			}
+			"preLaunchTask": "watch"
 		},
 		{
 			"type": "node",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,7 +25,7 @@
 			"port": 6009,
 			"restart": true,
 			"outFiles": [
-				"${workspaceRoot}/server/out/**/*.js"
+				"${workspaceRoot}/out/**/*.js"
 			]
 		}
 	],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -23,8 +23,9 @@
 			]
 		},
 		{
+			"label": "watch",
 			"type": "npm",
-			"script": "watch",
+			"script": "watch-ts",
 			"isBackground": true,
 			"group": {
 				"kind": "build",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "webpack:dev": "npm run clean && webpack --mode none",
     "precompile": "npm run lint",
     "compile": "npm run webpack",
-    "watch": "webpack watch --mode development"
+    "watch": "webpack watch --mode development",
+    "watch-ts": "tsc -b -w"
   },
   "devDependencies": {
     "@peggyjs/eslint-config": "0.0.1",

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,22 +1,19 @@
 {
   "compilerOptions": {
+    "composite": true,
     "module": "commonjs",
     "target": "es2020",
-    "lib": ["ES2020"],
-
+    "lib": [
+      "ES2020"
+    ],
     "sourceMap": true,
-    "incremental": false,
 
     "noImplicitAny": true,
-
-    "outDir": "out",
+    
+    "outDir": "../out",
+    "rootDir": "./src"
   },
   "include": [
-    "src"
-  ],
-  "references": [
-    {
-      "path": "./server",
-    }
+    "src",
   ]
 }


### PR DESCRIPTION
I'm not sure this solution is really the best, but this PR makes it so that local debug task uses tsc to compile.
Only really drawback is that an `out/server.d.ts` is created (cannot be turned off because of the composite project).

But I think this is still better then requiring an additional plugin (I think [this](https://marketplace.visualstudio.com/items?itemName=eamodio.tsl-problem-matcher) extension might solve the problem with the webpack watch task).
Also this makes it really fast to edit/start the debug instance.

For deployment webpack can still be used of course.

fixes #13 