### PR TITLE
Add inline syntax highlighting in JavaScript template string

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "webpack-cli": "^4.8.0"
       },
       "engines": {
-        "vscode": "^1.56.0"
+        "vscode": "^1.59.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,21 @@
         "embeddedLanguages": {
           "meta.embedded.block.javascript": "javascript"
         }
+      },
+      {
+        "injectTo": [
+          "source.js",
+          "source.ts",
+          "source.js.jsx",
+          "source.tsx",
+          "source.vue",
+          "source.svelte"
+        ],
+        "scopeName": "inline.peggy",
+        "path": "./syntaxes/peggy.js.json",
+        "embeddedLanguages": {
+          "meta.embedded.block.peggy": "peggy"
+        }
       }
     ],
     "snippets": [

--- a/syntaxes/peggy.js.json
+++ b/syntaxes/peggy.js.json
@@ -1,0 +1,25 @@
+{
+    "fileTypes": [
+      "js",
+      "jsx",
+      "mjs",
+      "cjs",
+      "es6",
+      "es",
+      "esm",
+      "ts",
+      "tsx",
+      "vue",
+      "svelte"
+    ],
+    "injectionSelector": "L:source -string",
+    "patterns": [
+      {
+        "contentName": "meta.embedded.block.peggy",
+        "begin": "(peg)(`)",
+        "end": "`",
+        "patterns": [{ "include": "source.peggy" }]
+      }
+    ],
+    "scopeName": "inline.peggy"
+  }

--- a/syntaxes/peggy.js.json
+++ b/syntaxes/peggy.js.json
@@ -16,7 +16,7 @@
     "patterns": [
       {
         "contentName": "meta.embedded.block.peggy",
-        "begin": "(peg)(`)",
+        "begin": "(peg|peggy)(`)",
         "end": "`",
         "patterns": [{ "include": "source.peggy" }]
       }


### PR DESCRIPTION
Resolves https://github.com/peggyjs/code-peggy-language/issues/21

Add inline syntax highlighting for peg in Javascript template strings

![image](https://user-images.githubusercontent.com/26973649/166924092-40fae605-0ebc-464e-b903-8c611590d64a.png)
