### PR TITLE
Wrap validateTextDocument in debounce

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
+        "debounce": "^1.2.1",
         "peggy": "^2.0.1",
         "vscode-languageclient": "^8.0.1",
         "vscode-languageserver": "^8.0.1",
@@ -16,6 +17,7 @@
       },
       "devDependencies": {
         "@peggyjs/eslint-config": "2.0.0",
+        "@types/debounce": "^1.2.1",
         "@types/node": "17.0.39",
         "@types/vscode": "^1.67.0",
         "@typescript-eslint/eslint-plugin": "^5.27.0",
@@ -183,6 +185,12 @@
         "@typescript-eslint/eslint-plugin": "^5.26.0",
         "@typescript-eslint/parser": "^5.26.0"
       }
+    },
+    "node_modules/@types/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-epMsEE85fi4lfmJUH/89/iV/LI+F5CvNIvmgs5g5jYFPfhO2S/ae8WSsLOKWdwtoaZw9Q2IhJ4tQ5tFCcS/4HA==",
+      "dev": true
     },
     "node_modules/@types/eslint": {
       "version": "8.4.2",
@@ -894,6 +902,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -2930,6 +2943,12 @@
       "dev": true,
       "requires": {}
     },
+    "@types/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-epMsEE85fi4lfmJUH/89/iV/LI+F5CvNIvmgs5g5jYFPfhO2S/ae8WSsLOKWdwtoaZw9Q2IhJ4tQ5tFCcS/4HA==",
+      "dev": true
+    },
     "@types/eslint": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.2.tgz",
@@ -3447,6 +3466,11 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="
     },
     "debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
   },
   "devDependencies": {
     "@peggyjs/eslint-config": "2.0.0",
+    "@types/debounce": "^1.2.1",
     "@types/node": "17.0.39",
     "@types/vscode": "^1.67.0",
     "@typescript-eslint/eslint-plugin": "^5.27.0",
@@ -121,6 +122,7 @@
     "webpack-cli": "^4.9.2"
   },
   "dependencies": {
+    "debounce": "^1.2.1",
     "peggy": "^2.0.1",
     "vscode-languageclient": "^8.0.1",
     "vscode-languageserver": "^8.0.1",

--- a/server/server.ts
+++ b/server/server.ts
@@ -22,6 +22,7 @@ import {
   createConnection,
 } from "vscode-languageserver/node";
 import { Position, TextDocument } from "vscode-languageserver-textdocument";
+import { debounce } from "debounce";
 
 function getWarnings(
   ast: peggy.ast.Grammar,
@@ -342,7 +343,7 @@ function addProblemDiagnostics(
   }
 }
 
-function validateTextDocument(doc: TextDocument): void {
+const validateTextDocument = debounce((doc: TextDocument): void => {
   const diagnostics: Diagnostic[] = [];
 
   try {
@@ -382,7 +383,7 @@ function validateTextDocument(doc: TextDocument): void {
 
   // Send the computed diagnostics to VS Code.
   connection.sendDiagnostics({ uri: doc.uri, diagnostics });
-}
+}, 150);
 
 documents.onDidChangeContent(change => {
   validateTextDocument(change.document);


### PR DESCRIPTION
To alleviate the issue reported in #31

Although you promised to implement it on your own, I thought I'll throw in a PR anyway, as I already had it implemented.

Feel free to reject it and implement differently on your own. The main thing here is really the decision of which library to use (or whether to just write debounce function on your own). Plus how long of a timeout to use.

I've played around with it a bit, and at least for now it seems to eliminate the main source of sluggishness in the extension.