### PR TITLE
Make the proxy-rules fix work in production mode

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -46,7 +46,15 @@ const PASSES: peggy.compiler.Stages = {
   check: peggy.compiler.passes.check,
   // Skip the removeProxyRules optimization,
   // which interferes with rule definition lookup. See issue #29
-  transform: peggy.compiler.passes.transform.filter(fn => fn.name !== "removeProxyRules"),
+  //
+  // Peggy includes two transforms: [removeProxyRules, inferenceMatchResult]
+  // There's no good way to pick them by name, as Peggy library doesn't
+  // directly export them and the names get removed during code minification.
+  // So we include inferenceMatchResult based solely on its position.
+  // See: https://github.com/peggyjs/peggy/blob/main/lib/compiler/index.js#L52
+  transform: [
+    peggy.compiler.passes.transform[1],
+  ],
   generate: [getWarnings],
 };
 


### PR DESCRIPTION
Again I discovered that my earlier fix for #29 doesn't quite work inside an actual compiled VSCode extension as the function names get shortened (or stripped completely) during code minification.

So I switched to picking the transform functions based on position. It's a fragile approach as it can break when Peggy decides to change around the order of these transforms in some future version.

Though frankly I haven't managed to figure out what the [inferenceMatchResult][] transform does. It might be that we don't need to have any transforms at all. That would be a much simpler solution, plus performance win from not running any of these transforms.

[inferenceMatchResult]: https://github.com/peggyjs/peggy/blob/main/lib/compiler/passes/inference-match-result.js