### PR TITLE
Underline locations of syntax errors

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -367,6 +367,8 @@ const validateTextDocument = debounce((doc: TextDocument): void => {
   } catch (error) {
     if (error instanceof peggy.GrammarError) {
       addProblemDiagnostics(error.problems, diagnostics);
+    } else if (error instanceof peggy.parser.SyntaxError) {
+      addProblemDiagnostics([["error", error.message, error.location, []]], diagnostics);
     } else {
       connection.console.error(error.toString());
       const d: Diagnostic = {


### PR DESCRIPTION
Currently when encountering a syntax error, the location of the error is not underlined (as with GrammarErrors). Instead the first line in the file is underlined and error logged in console:

![Screenshot 2022-12-16 at 20 06 14](https://user-images.githubusercontent.com/118201/208161958-6af5a7a3-7c04-463d-8f30-419cac107b9b.png)

With this fix, syntax errors are handled similarly to grammar errors:

![Screenshot 2022-12-16 at 20 07 21](https://user-images.githubusercontent.com/118201/208162057-102d864d-54ca-4d41-ad5d-7277bdc80316.png)
