### PR TITLE
Upgrade terser to 5.16.1 to eliminate vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2413,9 +2413,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.0.tgz",
-      "integrity": "sha512-JC6qfIEkPBd9j1SMO3Pfn+A6w2kQV54tv+ABQLgZr7dA3k/DL/OBoYSWxzVpZev3J+bUHXfr55L8Mox7AaNo6g==",
+      "version": "5.16.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
+      "integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",
@@ -4547,9 +4547,9 @@
       "dev": true
     },
     "terser": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.0.tgz",
-      "integrity": "sha512-JC6qfIEkPBd9j1SMO3Pfn+A6w2kQV54tv+ABQLgZr7dA3k/DL/OBoYSWxzVpZev3J+bUHXfr55L8Mox7AaNo6g==",
+      "version": "5.16.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
+      "integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
       "dev": true,
       "requires": {
         "@jridgewell/source-map": "^0.3.2",


### PR DESCRIPTION
[Terser](https://www.npmjs.com/package/terser) is used by Webpack to do minification, so I think not really a serious issue for this library, but NPM complains about this with some red and disturbing warnings.

![Screenshot 2022-12-17 at 17 31 19](https://user-images.githubusercontent.com/118201/208249345-5f7aa0a5-eace-4b62-a6c9-5af6fc594c8d.png)
