### PR TITLE
Fix: Bracket pairing issues in VS Code caused by charclass scope

### DIFF
--- a/syntaxes/peggy.json
+++ b/syntaxes/peggy.json
@@ -92,7 +92,7 @@
         "charclass": {
             "begin": "\\[",
             "end": "\\]",
-            "name": "declaration.keyword.peggy",
+            "name": "string.regexp.peggy",
             "patterns": [
                 {
                     "match": "\\\\.",


### PR DESCRIPTION
Hi team,

I've noticed that parentheses within character classes (`charclass`) are breaking the bracket pairing feature in VS Code.

VS Code's bracket pairing logic is designed to ignore parentheses that appear within certain scopes, such as strings (where they often appear individually and unmatched), to prevent incorrect pairing.
However, the current scope name for `charclass` is `declaration.keyword.peggy`, which is not treated as a string-like scope. This causes the bracket pairing to malfunction when parentheses are used inside character classes.

To address this, I propose changing the scope name for `charclass` from `declaration.keyword.peggy` to `string.regex.peggy`.
This change should allow VS Code to correctly interpret parentheses within character classes, thereby fixing the bracket pairing issue.

Please let me know your thoughts on this proposal.

Before

![スクリーンショット 2025-05-20 162941](https://github.com/user-attachments/assets/b5604edd-0204-49fb-b016-e75a619e3dc6)

After

![スクリーンショット 2025-05-20 183214](https://github.com/user-attachments/assets/0239fc49-547a-4d87-9e96-09f9e3c47d1d)

Thanks,
aoitaku