### PR TITLE
Define problem matchers

### DIFF
--- a/client/client.ts
+++ b/client/client.ts
@@ -33,6 +33,7 @@ export function activate(context: ExtensionContext): void {
   const clientOptions: LanguageClientOptions = {
     // Register the server for plain text documents
     documentSelector: [{ language: "peggy" }],
+    diagnosticCollectionName: "peggy",
     synchronize: {
       configurationSection: "peggyLanguageServer",
     },

--- a/package.json
+++ b/package.json
@@ -118,6 +118,39 @@
         "title": "Peggy Live from rule under cursor",
         "category": "preview"
       }
+    ],
+    "problemMatchers": [
+      {
+        "name": "peggy",
+        "label": "peggy check problems",
+        "owner": "peggy",
+        "source": "peggy-language",
+        "applyTo": "closedDocuments",
+        "fileLocation": "autoDetect",
+        "pattern": [
+          {
+            "regexp": "^(Error|error|warning|info)\\S*: (.*)$",
+            "severity": 1,
+            "message": 2
+          },
+          {
+            "regexp": "^ --> ([^:]+):(\\d+):(\\d+)$",
+            "file": 1,
+            "line": 2,
+            "column": 3
+          }
+        ]
+      },
+      {
+        "name": "peggy-watch",
+        "base": "$peggy",
+        "label": "peggy check watch problems",
+        "background": {
+          "activeOnStart": false,
+          "beginsPattern": "^\"(.+)\" changed...$",
+          "endsPattern": "^(Wrote|Failed writing): (\".+\")$"
+        }
+      }
     ]
   },
   "scripts": {


### PR DESCRIPTION
PR to resolve #61.

As noted in #61, the regular expression patterns may be imperfect. Sorry for that. The syntax to define a problem matcher is documented in VS Code Extension API site, [Integrate with External Tools via Tasks - Defining a problem matcher](https://code.visualstudio.com/docs/debugtest/tasks#_defining-a-problem-matcher).

Let me explain a little about what I know about keys in package.json. Please modify them if you think not appropriate.

- `name`: this name following `$` is used by a user in `problemMatcher` in tasks.json. I created `peggy` and `peggy-watch`.
- `label`: I don't know when and where it is used. I tentatively set a bit long description, following [another one's code](https://github.com/eamodio/vscode-tsl-problem-matcher/blob/main/package.json).
- `owner`: **important**. The extension has already had a feature to report problems of open files. To avoid duplication of problems between it and the problem matcher, the name of diagnostic collection must match this value. Otherwise setting `"applyTo": "closedDocuments"` at the configuration point does not work as expected.
- `source`: displayed in a _Problems_ list.