### PR TITLE
Fix VS Code build task settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"dbaeumer.vscode-eslint"
+	]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
 			"outFiles": [
 				"${workspaceRoot}/out/**/*.js"
 			],
-			"preLaunchTask": "watch"
+			"preLaunchTask": "watch:webpack"
 		},
 		{
 			"type": "node",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -23,9 +23,9 @@
 			]
 		},
 		{
-			"label": "watch",
+			"label": "watch:webpack",
 			"type": "npm",
-			"script": "watch:tsc",
+			"script": "watch:webpack",
 			"isBackground": true,
 			"group": {
 				"kind": "build",
@@ -36,8 +36,33 @@
 				"reveal": "never"
 			},
 			"problemMatcher": [
+				"$ts-webpack-watch"
+			]
+		},
+		{
+			"label": "watch:tsc-no-emit",
+			"type": "npm",
+			"script": "watch:tsc-no-emit",
+			"isBackground": true,
+			"group": "build",
+			"presentation": {
+				"panel": "dedicated",
+				"reveal": "never"
+			},
+			"problemMatcher": [
 				"$tsc-watch"
 			]
+		},
+		{
+			"label": "watch",
+			"dependsOn": [
+				"watch:tsc-no-emit",
+				"watch:webpack"
+			],
+			"presentation": {
+				"reveal": "never"
+			},
+			"group": "build"
 		}
 	]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
       },
       "devDependencies": {
         "@peggyjs/eslint-config": "6.0.3",
-        "@types/node": "24.0.10",
+        "@types/node": "^22.16.0",
         "@types/vscode": "^1.101.0",
         "@vscode/vsce": "3.6.0",
         "eslint": "^9.30.1",
@@ -1213,13 +1213,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.0.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.10.tgz",
-      "integrity": "sha512-ENHwaH+JIRTDIEEbDK6QSQntAYGtbvdDXnMXnZaZ6k13Du1dPMmprkEHIL7ok2Wl2aZevetwTAb5S+7yIF+enA==",
+      "version": "22.16.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.16.0.tgz",
+      "integrity": "sha512-B2egV9wALML1JCpv3VQoQ+yesQKAmNMBIAY7OteVrikcOcAkWm+dGL6qpeCktPjAv6N1JLnhbNiqS35UpFyBsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.8.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -7416,9 +7416,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
   },
   "devDependencies": {
     "@peggyjs/eslint-config": "6.0.3",
-    "@types/node": "24.0.10",
+    "@types/node": "^22.16.0",
     "@types/vscode": "^1.101.0",
     "@vscode/vsce": "3.6.0",
     "eslint": "^9.30.1",

--- a/package.json
+++ b/package.json
@@ -163,6 +163,8 @@
     "build": "npm run webpack",
     "watch:webpack": "webpack watch --mode development",
     "watch:tsc": "tsc -b -w",
+    "compile:tsc-no-emit": "tsc --noEmit --project tsconfig.json",
+    "watch:tsc-no-emit": "tsc --watch --noEmit --project tsconfig.json",
     "package": "vsce package --no-dependencies"
   },
   "devDependencies": {


### PR DESCRIPTION
Thankfully, the Build Task settings for VS Code were added at PR #70 as the response to issue  #68. This PR is a request of a few modification on that.

At the moment of PR #70, `preLaunchTask` of the default build task (F5 / Ctrl-Shift-B) is defined as `"watch"` in launch.json, which calls `"watch"` in tasks.json and then calls `"watch:tsc"` in package.json, and then finally calls `tsc -b -w`. This produced the following errors and failed to compile in my environment:

<img width="891" alt="screenshot problems of tsc -w" src="https://github.com/user-attachments/assets/d8e78a13-4970-466f-94d9-d27d19dee0d5" />

I found the extension can be compiled without error when `webpack` is used instead of `tsc`, and it looks the extension in the market place is in fact compiled by `webpack`. I changed the build setting to use `watch:webpack` npm script. Compilation using `tsc` may be still worthy in the view of stricter type checking (while I don't know the difference of `webpack+tsloader` and `tsc` well), so I renamed the task using `tsc` and left it in a file. I added `extensions.json` to recommend a developer to install `$ts-webpack-watch`, which is not VS Code built-in but included in the extension described here.

I also found that 2nd-6th `tsc` errors are probably due to incompatibility of VS Code API with the latest Node 24.x. In release note it is written that VS Code just recently updated internal Node.js version from V20 to V22 at [v1.101](https://code.visualstudio.com/updates/v1_101#_extension-authoring). `generator-code` templates also specified `"@types/node": "20.x"` in package.json. This PR includes downgrading of @types/node to 22.x, which removes these errors.

I don't know the way to remove the first error.