### PR TITLE
fix: issue in which problems remain after file is closed (again)

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -419,7 +419,7 @@ documents.onDidClose(change => {
       uri: change.document.uri,
       diagnostics: [],
     });
-  }, 150);
+  }, globalSettings.debounceMS);
 });
 
 documents.onDidChangeContent(change => {


### PR DESCRIPTION
Hi, @hildjj. Thank you for continuous updates.

This is I think a trivial PR and so I'm posting here directly, without making an issue.

I found the problem that had been fixed at Issue #58 and PR #59 occurs again (but now it occurs sometimes, not always). 
The problem tends to occur frequently when the debounce time is large, e.g., 1000 msec. This will be relate to the recent extension update that has made the debounce time configurable and has changed its default value from 150 to 200 msec. The fix is quite simple. Please check it.